### PR TITLE
feat: add example usage for the data-read-as-digits attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Document</title>
-    <script src="https://storage.googleapis.com/assets.meld.cx/agent/1.0.40/Agent.js"></script>
+    <script src="https://storage.googleapis.com/assets.meld.cx/agent/1.0.42/Agent.js"></script>
     <style>
         html, body {
             font-family: Arial, Helvetica, sans-serif;

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Document</title>
-    <script src="https://storage.googleapis.com/assets.meld.cx/agent/1.0.33/Agent.js"></script>
+    <script src="https://storage.googleapis.com/assets.meld.cx/agent/1.0.40/Agent.js"></script>
     <style>
         html, body {
             font-family: Arial, Helvetica, sans-serif;
@@ -32,6 +32,7 @@
 <body>
     <h1>MeldCX AgentM Accessibility Example App</h1>
     <hr>
+    The following link has the <code>data-read-as-digits</code> attribute set on the element like so <code>&lt;a&nbsp;data-read-as-digits&gt;Link&lt;/a&gt;</code><br/>
     <a data-read-as-digits tabIndex="0">The following number will be read as independant digits and "symbols". 1,223.44</a><br>
     <a tabIndex="0">The following number will be read as a whole. 781.44</a><br>
     <a tabIndex="0" data-read-as-digits>The following will be read as independant digits and can tolerate symbols. Room #756</a><br>


### PR DESCRIPTION
chore: bump agent version